### PR TITLE
fix: commit author forced to `github-actions[bot]`

### DIFF
--- a/.github/workflows/github-users-activity.yaml
+++ b/.github/workflows/github-users-activity.yaml
@@ -57,3 +57,7 @@ jobs:
           commit_message: Automated update timeline.png
           file_pattern: timeline.png
           branch: main
+          # Force changes to be from github-actions vs local repo owner to prevent affecting usage activity with updates
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
This pull request includes a small but important update to the `.github/workflows/github-users-activity.yaml` file. The change ensures that commits made by the workflow are attributed to the `github-actions[bot]` user, preventing these automated updates from affecting usage activity metrics.